### PR TITLE
Stream ModelOutputs

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -4883,7 +4883,7 @@ if TYPE_CHECKING:
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
 
     # Generation
-    from .generation import GenerationConfig, TextIteratorStreamer, TextStreamer
+    from .generation import GenerationConfig, TextIteratorStreamer, TextStreamer, OutputIteratorStreamer
     from .hf_argparser import HfArgumentParser
 
     # Integrations

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -19,7 +19,7 @@ from ..utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_availab
 
 _import_structure = {
     "configuration_utils": ["GenerationConfig"],
-    "streamers": ["TextIteratorStreamer", "TextStreamer"],
+    "streamers": ["TextIteratorStreamer", "TextStreamer", "OutputIteratorStreamer"],
 }
 
 try:

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -81,9 +81,11 @@ class OutputStreamer(BaseStreamer):
         When the buffer is ready, flush it and do something with the values it was holding
         """
         if len(self.cache) > 1:
-            values = self.cache[:]
+            values = self.cache[:] # gives us a list.... : TODO: iterate over items instead of... this.
+        elif len(self.cache) == 1:
+            values = self.cache[0] # gives us an item.
         else:
-            values = self.cache[0]
+            raise ValueError("on_ready() called on an empty buffer. This should not happen. Report this error.")
         self.cache = []
         return self.process_outgoing_values(values)
 
@@ -140,7 +142,8 @@ class OutputIteratorStreamer(OutputStreamer):
             return value
 
     def end(self):
-        self.on_ready() # flush the cache if there's anything in it
+        if self.cache:
+            self.on_ready() # flush the cache if there's anything in it
         self.queue.put(self.stop_signal)
 
 

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -84,6 +84,7 @@ class OutputStreamer(BaseStreamer):
             values = self.cache[:] # gives us a list.... : TODO: iterate over items instead of... this.
         elif len(self.cache) == 1:
             values = self.cache[0] # gives us an item.
+            values = [values] # put it in a list to be consistent with multi-valued output supported above
         else:
             raise ValueError("on_ready() called on an empty buffer. This should not happen. Report this error.")
         self.cache = []

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from transformers.generation.utils import GenerateDecoderOnlyOutput
+from transformers.generation.utils import (GenerateDecoderOnlyOutput, GenerateEncoderDecoderOutput)
 
 if TYPE_CHECKING:
     from ..models.auto import AutoTokenizer
@@ -151,7 +151,7 @@ class TokenStreamer(OutputStreamer):
     Filters the output stream on tokens to replicate legacy behavior
     """
     def _filter_func(self, value):
-        if isinstance(value, GenerateDecoderOnlyOutput): #TODO: *or* GenerateEncoderDecoderOutput
+        if isinstance(value, (GenerateDecoderOnlyOutput, GenerateEncoderDecoderOutput)):
             return value.sequences.cpu()
         else:
             return value.cpu()

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -53,9 +53,6 @@ class OutputStreamer(BaseStreamer):
         if cache is None:
             cache = []
         self.cache = cache # incoming unprocessed outputs
-        #if queue is None:
-        #    queue = Queue()
-        #self.queue = queue # outgoing finalized outputs
 
     def _filter_func(self, value):
         """

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -141,6 +141,9 @@ class OutputIteratorStreamer(OutputStreamer):
         else:
             return value
 
+    def end(self):
+        self.queue.put(self.stop_signal)
+
 
 ###############################
 

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -94,12 +94,9 @@ class OutputStreamer(BaseStreamer):
         """
         What to do with the values that were previously in the buffer
         """
-        #self.queue.put(values)
-        #print(values)
         return values
 
     def put(self, value):
-        #print(type(value))
         value = self.process_incoming_value(value)
         if value is not None:
             if isinstance(value, list):
@@ -131,17 +128,22 @@ class OutputIteratorStreamer(OutputStreamer):
         """
         self.queue.put(values)
 
+
     def __iter__(self):
         return self
 
     def __next__(self):
         value = self.queue.get(timeout=self.timeout)
+        # unclear why all outputs are being wrapped in a list except very last.
+        # frankly... none of them should be? why are any wrapped in a list? maybe something to do with Queue.put?
+        #print(("__next__",value))
         if value == self.stop_signal:
             raise StopIteration()
         else:
             return value
 
     def end(self):
+        self.on_ready() # flush the cache if there's anything in it
         self.queue.put(self.stop_signal)
 
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -366,7 +366,8 @@ class GenerationMixin:
     learn more about decoding strategies refer to the [text generation strategies guide](../generation_strategies).
     """
 
-    def output_constructor(self, return_dict_in_generate, **output_kargs):
+    #def _prepare_output(self, return_dict_in_generate, **output_kargs):
+    def _prepare_output(self, return_dict_in_generate, **output_kargs):
         # potential better names:
         # * _prepare_output
         if return_dict_in_generate:
@@ -1441,7 +1442,7 @@ class GenerationMixin:
         else:
             input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
 
-        # def output_constructor(**output_kargs):
+        # def _prepare_output(**output_kargs):
         #     if generation_config.return_dict_in_generate:
         #         cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
         #         outv = cls(**output_kargs)
@@ -1457,7 +1458,7 @@ class GenerationMixin:
             # output_stub = GenerateDecoderOnlyOutput(
             #     sequences=input_ids,
             # )
-            output_stub = self.output_constructor(return_dict_in_generate=generation_config.return_dict_in_generate, sequences=input_ids)
+            output_stub = self._prepare_output(return_dict_in_generate=generation_config.return_dict_in_generate, sequences=input_ids)
             streamer.put(output_stub)
 
         # 6. Prepare `max_length` depending on other stopping criteria.
@@ -2213,7 +2214,7 @@ class GenerationMixin:
                     raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
                 next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
 
-            # def output_constructor(**output_kargs):
+            # def _prepare_output(**output_kargs):
             #     if return_dict_in_generate:
             #         cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
             #         outv = cls(**output_kargs)
@@ -2232,7 +2233,7 @@ class GenerationMixin:
                 #     scores=scores,
                 #     logits=logits,
                 # )
-                output_stub = self.output_constructor(
+                output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     sequences=next_tokens,
                     scores=scores,
@@ -2453,7 +2454,7 @@ class GenerationMixin:
             )
 
         # feels like this is where this logic could go...
-        # def output_constructor(**output_kargs):
+        # def _prepare_output(**output_kargs):
         #     if return_dict_in_generate:
         #         cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
         #         outv = cls(**output_kargs)
@@ -2535,7 +2536,7 @@ class GenerationMixin:
                 #     scores=next_tokens_scores,
                 #     logits=next_token_logits, # why are these names inconsistent....
                 # )
-                output_stub = self.output_constructor(
+                output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     sequences=next_tokens,
                     scores=next_tokens_scores,
@@ -2838,7 +2839,7 @@ class GenerationMixin:
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
 
-            # def output_constructor(**output_kargs):
+            # def _prepare_output(**output_kargs):
             #     if return_dict_in_generate:
             #         cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
             #         outv = cls(**output_kargs)
@@ -2859,7 +2860,7 @@ class GenerationMixin:
                 #         logits=next_token_logits,
                 #     )
                 # )
-                output_stub = self.output_constructor(
+                output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     #sequences=next_tokens[:, None] # doesn't seem to make a difference. Handled downstream
                     sequences=next_tokens,  # this seems to be getting coerced to float somewhere?
@@ -4689,7 +4690,7 @@ class GenerationMixin:
             # Because of this last token, assisted generation search reduces to a normal greedy search/sample if there
             # is no match.
 
-            # def output_constructor(**output_kargs):
+            # def _prepare_output(**output_kargs):
             #     if return_dict_in_generate:
             #         cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
             #         outv = cls(**output_kargs)
@@ -4707,7 +4708,7 @@ class GenerationMixin:
                 #     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)), # todo: just slice a view into the tensor... new_logits[:, :(n_matches+1), :], right?
                 #     logits=next_token_logits,
                 # )
-                output_stub = self.output_constructor(
+                output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     sequences=valid_tokens,
                     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)),

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -373,7 +373,7 @@ class GenerationMixin:
             **output_kargs):
         if return_dict_in_generate:
             if self.config.is_encoder_decoder:
-                cls = GenerateEncoderDecoderOnlyOutput
+                cls = GenerateEncoderDecoderOutput
             else:
                 cls =GenerateDecoderOnlyOutput
                 if 'decoder_attentions' in output_kargs:
@@ -1969,6 +1969,7 @@ class GenerationMixin:
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
+        encoder_attentions = encoder_hidden_states = None # initialize variables for self._prepare_output
         if return_dict_in_generate and self.config.is_encoder_decoder:
             encoder_attentions = model_kwargs["encoder_outputs"].get("attentions") if output_attentions else None
             encoder_hidden_states = (
@@ -2261,42 +2262,18 @@ class GenerationMixin:
                     past_key_values.append(tuple(layer_past_key_values))
                 model_kwargs["past_key_values"] = tuple(past_key_values)
 
-            return self._prepare_output(
-                return_dict_in_generate=return_dict_in_generate,
-                sequences=input_ids,
-                scores=scores,
-                logits=raw_logits,
-                encoder_attentions=encoder_attentions,
-                encoder_hidden_states=encoder_hidden_states,
-                decoder_attentions=decoder_attentions,
-                cross_attentions=cross_attentions,
-                decoder_hidden_states=decoder_hidden_states,
-                past_key_values=model_kwargs.get("past_key_values")
-            )
-        #
-        #     if self.config.is_encoder_decoder:
-        #         return GenerateEncoderDecoderOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             encoder_attentions=encoder_attentions,
-        #             encoder_hidden_states=encoder_hidden_states,
-        #             decoder_attentions=decoder_attentions,
-        #             cross_attentions=cross_attentions,
-        #             decoder_hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        #     else:
-        #         return GenerateDecoderOnlyOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             attentions=decoder_attentions,
-        #             hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        # else:
-        #     return input_ids
+        return self._prepare_output(
+            return_dict_in_generate=return_dict_in_generate,
+            sequences=input_ids,
+            scores=scores,
+            logits=raw_logits,
+            encoder_attentions=encoder_attentions,
+            encoder_hidden_states=encoder_hidden_states,
+            decoder_attentions=decoder_attentions,
+            cross_attentions=cross_attentions,
+            decoder_hidden_states=decoder_hidden_states,
+            past_key_values=model_kwargs.get("past_key_values")
+        )
 
     def greedy_search(
         self,
@@ -2564,31 +2541,6 @@ class GenerationMixin:
             decoder_hidden_states=decoder_hidden_states,
             past_key_values=model_kwargs.get("past_key_values")
         )
-        #
-        # if return_dict_in_generate:
-        #     if self.config.is_encoder_decoder:
-        #         return GenerateEncoderDecoderOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             encoder_attentions=encoder_attentions,
-        #             encoder_hidden_states=encoder_hidden_states,
-        #             decoder_attentions=decoder_attentions,
-        #             cross_attentions=cross_attentions,
-        #             decoder_hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        #     else:
-        #         return GenerateDecoderOnlyOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             attentions=decoder_attentions,
-        #             hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        # else:
-        #     return input_ids
 
     def sample(
         self,
@@ -2759,6 +2711,7 @@ class GenerationMixin:
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
+        encoder_attentions = encoder_hidden_states = None # initialize variables for self._prepare_output
         if return_dict_in_generate and self.config.is_encoder_decoder:
             encoder_attentions = model_kwargs["encoder_outputs"].get("attentions") if output_attentions else None
             encoder_hidden_states = (
@@ -2867,30 +2820,43 @@ class GenerationMixin:
         if streamer is not None:
             streamer.end()
 
-        if return_dict_in_generate:
-            if self.config.is_encoder_decoder:
-                return GenerateEncoderDecoderOutput(
-                    sequences=input_ids,
-                    scores=scores,
-                    logits=raw_logits,
-                    encoder_attentions=encoder_attentions,
-                    encoder_hidden_states=encoder_hidden_states,
-                    decoder_attentions=decoder_attentions,
-                    cross_attentions=cross_attentions,
-                    decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
-                )
-            else:
-                return GenerateDecoderOnlyOutput(
-                    sequences=input_ids,
-                    scores=scores,
-                    logits=raw_logits,
-                    attentions=decoder_attentions,
-                    hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
-                )
-        else:
-            return input_ids
+        return self._prepare_output(
+            return_dict_in_generate=return_dict_in_generate,
+            sequences=input_ids,
+            scores=scores,
+            logits=raw_logits,
+            encoder_attentions=encoder_attentions,
+            encoder_hidden_states=encoder_hidden_states,
+            decoder_attentions=decoder_attentions,
+            cross_attentions=cross_attentions,
+            decoder_hidden_states=decoder_hidden_states,
+            past_key_values=model_kwargs.get("past_key_values")
+        )
+
+        # if return_dict_in_generate:
+        #     if self.config.is_encoder_decoder:
+        #         return GenerateEncoderDecoderOutput(
+        #             sequences=input_ids,
+        #             scores=scores,
+        #             logits=raw_logits,
+        #             encoder_attentions=encoder_attentions,
+        #             encoder_hidden_states=encoder_hidden_states,
+        #             decoder_attentions=decoder_attentions,
+        #             cross_attentions=cross_attentions,
+        #             decoder_hidden_states=decoder_hidden_states,
+        #             past_key_values=model_kwargs.get("past_key_values"),
+        #         )
+        #     else:
+        #         return GenerateDecoderOnlyOutput(
+        #             sequences=input_ids,
+        #             scores=scores,
+        #             logits=raw_logits,
+        #             attentions=decoder_attentions,
+        #             hidden_states=decoder_hidden_states,
+        #             past_key_values=model_kwargs.get("past_key_values"),
+        #         )
+        # else:
+        #     return input_ids
 
     def _temporary_reorder_cache(self, past_key_values, beam_idx):
         """
@@ -4786,30 +4752,6 @@ class GenerationMixin:
             decoder_hidden_states=decoder_hidden_states,
             past_key_values=model_kwargs.get("past_key_values")
         )
-        #if return_dict_in_generate:
-        #     if self.config.is_encoder_decoder:
-        #         return GenerateEncoderDecoderOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             encoder_attentions=encoder_attentions,
-        #             encoder_hidden_states=encoder_hidden_states,
-        #             decoder_attentions=decoder_attentions,
-        #             cross_attentions=cross_attentions,
-        #             decoder_hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        #     else:
-        #         return GenerateDecoderOnlyOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             attentions=decoder_attentions,
-        #             hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        # else:
-        #     return input_ids
 
 
 def _speculative_sampling(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1430,7 +1430,7 @@ class GenerationMixin:
         else:
             input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
 
-        def output_contructor(**output_kargs):
+        def output_constructor(**output_kargs):
             if generation_config.return_dict_in_generate:
                 cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
                 outv = cls(**output_kargs)
@@ -1446,7 +1446,7 @@ class GenerationMixin:
             # output_stub = GenerateDecoderOnlyOutput(
             #     sequences=input_ids,
             # )
-            output_stub = output_contructor(sequences=input_ids)
+            output_stub = output_constructor(sequences=input_ids)
             streamer.put(output_stub)
 
         # 6. Prepare `max_length` depending on other stopping criteria.
@@ -2202,7 +2202,7 @@ class GenerationMixin:
                     raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
                 next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
 
-            def output_contructor(**output_kargs):
+            def output_constructor(**output_kargs):
                 if return_dict_in_generate:
                     cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
                     outv = cls(**output_kargs)
@@ -2221,7 +2221,7 @@ class GenerationMixin:
                 #     scores=scores,
                 #     logits=logits,
                 # )
-                output_stub = output_contructor(
+                output_stub = output_constructor(
                     sequences=next_tokens,
                     scores=scores,
                     logits=logits,
@@ -2441,7 +2441,7 @@ class GenerationMixin:
             )
 
         # feels like this is where this logic could go...
-        def output_contructor(**output_kargs):
+        def output_constructor(**output_kargs):
             if return_dict_in_generate:
                 cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
                 outv = cls(**output_kargs)
@@ -2523,7 +2523,7 @@ class GenerationMixin:
                 #     scores=next_tokens_scores,
                 #     logits=next_token_logits, # why are these names inconsistent....
                 # )
-                output_stub = output_contructor(
+                output_stub = output_constructor(
                     sequences=next_tokens,
                     scores=next_tokens_scores,
                     logits=next_token_logits,
@@ -4675,7 +4675,7 @@ class GenerationMixin:
             # Because of this last token, assisted generation search reduces to a normal greedy search/sample if there
             # is no match.
 
-            def output_contructor(**output_kargs):
+            def output_constructor(**output_kargs):
                 if return_dict_in_generate:
                     cls = GenerateEncoderDecoderOnlyOutput if self.config.is_encoder_decoder else GenerateDecoderOnlyOutput
                     outv = cls(**output_kargs)
@@ -4693,7 +4693,7 @@ class GenerationMixin:
                 #     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)), # todo: just slice a view into the tensor... new_logits[:, :(n_matches+1), :], right?
                 #     logits=next_token_logits,
                 # )
-                output_stub = output_contructor(
+                output_stub = output_constructor(
                     sequences=valid_tokens,
                     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)),
                     # todo: just slice a view into the tensor... new_logits[:, :(n_matches+1), :], right?

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -369,7 +369,6 @@ class GenerationMixin:
     def _prepare_output(
             self, *,
             return_dict_in_generate,
-            # output_logits output_scores output_attentions output_hidden_states # ... I think we only need these if there's a situation where we need to construct a tuple
             **output_kargs):
         if return_dict_in_generate:
             if self.config.is_encoder_decoder:
@@ -2793,7 +2792,6 @@ class GenerationMixin:
             # sample
             probs = nn.functional.softmax(next_token_scores, dim=-1)
             next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
-            #print(next_tokens.dtype, input_ids.dtype) # both int64 here
 
             # finished sentences should have their next token be a padding token
             if eos_token_id is not None:
@@ -2854,31 +2852,6 @@ class GenerationMixin:
             decoder_hidden_states=decoder_hidden_states,
             past_key_values=model_kwargs.get("past_key_values")
         )
-
-        # if return_dict_in_generate:
-        #     if self.config.is_encoder_decoder:
-        #         return GenerateEncoderDecoderOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             encoder_attentions=encoder_attentions,
-        #             encoder_hidden_states=encoder_hidden_states,
-        #             decoder_attentions=decoder_attentions,
-        #             cross_attentions=cross_attentions,
-        #             decoder_hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        #     else:
-        #         return GenerateDecoderOnlyOutput(
-        #             sequences=input_ids,
-        #             scores=scores,
-        #             logits=raw_logits,
-        #             attentions=decoder_attentions,
-        #             hidden_states=decoder_hidden_states,
-        #             past_key_values=model_kwargs.get("past_key_values"),
-        #         )
-        # else:
-        #     return input_ids
 
     def _temporary_reorder_cache(self, past_key_values, beam_idx):
         """
@@ -4763,10 +4736,6 @@ class GenerationMixin:
             candidate_generator.assistant_model.generation_config.num_assistant_tokens = (
                 candidate_generator.num_assistant_tokens
             )
-
-        # already took care of this above.
-        #if not self.config.is_encoder_decoder:
-        #    encoder_attentions = encoder_hidden_states = None
 
         return self._prepare_output(
             return_dict_in_generate=return_dict_in_generate,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2226,8 +2226,8 @@ class GenerationMixin:
                 output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     sequences=next_tokens,
-                    scores=scores,
-                    logits=logits,
+                    scores=(scores,),
+                    logits=(logits,),
                     encoder_attentions=None,
                     encoder_hidden_states=None,
                     decoder_attentions=None,
@@ -2508,8 +2508,8 @@ class GenerationMixin:
                 output_stub = self._prepare_output(
                     return_dict_in_generate=return_dict_in_generate,
                     sequences=next_tokens,
-                    scores=next_tokens_scores,
-                    logits=next_token_logits,
+                    scores=(next_tokens_scores,),
+                    logits=(next_token_logits,),
                     encoder_attentions=None,
                     encoder_hidden_states=None,
                     decoder_attentions=None,
@@ -2807,8 +2807,8 @@ class GenerationMixin:
                     return_dict_in_generate=return_dict_in_generate,
                     #sequences=next_tokens[:, None] # doesn't seem to make a difference. Handled downstream
                     sequences=next_tokens,  # this seems to be getting coerced to float somewhere?
-                    scores=next_token_scores,
-                    logits=next_token_logits,
+                    scores=(next_token_scores,),
+                    logits=(next_token_logits,),
                     encoder_attentions=None,
                     encoder_hidden_states=None,
                     decoder_attentions=None,
@@ -4636,7 +4636,7 @@ class GenerationMixin:
                     sequences=valid_tokens,
                     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)),
                     # todo: just slice a view into the tensor... new_logits[:, :(n_matches+1), :], right?
-                    logits=next_token_logits,
+                    logits=(next_token_logits,),
                     encoder_attentions=None,
                     encoder_hidden_states=None,
                     decoder_attentions=None,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1460,7 +1460,11 @@ class GenerationMixin:
         # echo back the prompt
         # NB: if user wants prompt logits, this will prob need to be moved down
         if streamer is not None:
-            output_stub = self._prepare_output(return_dict_in_generate=generation_config.return_dict_in_generate, sequences=input_ids)
+            output_stub = self._prepare_output(
+                return_dict_in_generate=generation_config.return_dict_in_generate,
+                sequences=input_ids,
+                # no scores/logits/attention/hidden here because they haven't been computed yet.
+            )
             streamer.put(output_stub)
 
         # 6. Prepare `max_length` depending on other stopping criteria.
@@ -2225,6 +2229,12 @@ class GenerationMixin:
                     sequences=next_tokens,
                     scores=scores,
                     logits=logits,
+                    encoder_attentions=None,
+                    encoder_hidden_states=None,
+                    decoder_attentions=None,
+                    cross_attentions=None,
+                    decoder_hidden_states=None,
+                    past_key_values=None,
                 )
                 streamer.put(output_stub)
 
@@ -2501,6 +2511,12 @@ class GenerationMixin:
                     sequences=next_tokens,
                     scores=next_tokens_scores,
                     logits=next_token_logits,
+                    encoder_attentions=None,
+                    encoder_hidden_states=None,
+                    decoder_attentions=None,
+                    cross_attentions=None,
+                    decoder_hidden_states=None,
+                    past_key_values=None,
                 )
                 streamer.put(output_stub)
 
@@ -2795,6 +2811,12 @@ class GenerationMixin:
                     sequences=next_tokens,  # this seems to be getting coerced to float somewhere?
                     scores=next_token_scores,
                     logits=next_token_logits,
+                    encoder_attentions=None,
+                    encoder_hidden_states=None,
+                    decoder_attentions=None,
+                    cross_attentions=None,
+                    decoder_hidden_states=None,
+                    past_key_values=None,
                     )
                 streamer.put(output_stub)
 
@@ -4642,6 +4664,12 @@ class GenerationMixin:
                     scores=tuple(new_logits[:, i, :] for i in range(n_matches + 1)),
                     # todo: just slice a view into the tensor... new_logits[:, :(n_matches+1), :], right?
                     logits=next_token_logits,
+                    encoder_attentions=None,
+                    encoder_hidden_states=None,
+                    decoder_attentions=None,
+                    cross_attentions=None,
+                    decoder_hidden_states=None,
+                    past_key_values=None,
                 )
                 streamer.put(output_stub)
             new_cur_len = input_ids.shape[-1]

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1434,7 +1434,10 @@ class GenerationMixin:
         # NB: if user wants prompt logits, this will prob need to be moved down
         if streamer is not None:
             #streamer.put(input_ids.cpu())
-            output_stub = GenerateDecoderOnlyOutput(sequences=input_ids) # Do we need an OutputStub type?
+            output_stub = GenerateDecoderOnlyOutput(
+                sequences=input_ids,
+                #scores=None # uh....
+            ) # Do we need an OutputStub type?
             streamer.put(output_stub)
 
         # 6. Prepare `max_length` depending on other stopping criteria.
@@ -2197,7 +2200,7 @@ class GenerationMixin:
                 #streamer.put(next_tokens.cpu())
                 output_stub = GenerateDecoderOnlyOutput(
                     sequences=next_tokens,
-                    scores=None,
+                    scores=scores,
                     logits=logits,
                 )
                 streamer.put(output_stub)
@@ -2480,8 +2483,13 @@ class GenerationMixin:
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
             if streamer is not None:
                 #streamer.put(next_tokens.cpu())
-                output_stub = GenerateDecoderOnlyOutput(sequences=next_tokens)
+                output_stub = GenerateDecoderOnlyOutput(
+                    sequences=next_tokens,
+                    scores=next_tokens_scores,
+                    logits=next_token_logits, # why are these names inconsistent....
+                )
                 streamer.put(output_stub)
+
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs,
                 model_kwargs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1435,7 +1435,7 @@ class GenerationMixin:
         if streamer is not None:
             #streamer.put(input_ids.cpu())
             output_stub = GenerateDecoderOnlyOutput(sequences=input_ids) # Do we need an OutputStub type?
-            streamer.put(input_ids)
+            streamer.put(output_stub)
 
         # 6. Prepare `max_length` depending on other stopping criteria.
         input_ids_length = input_ids.shape[-1]

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2183,7 +2183,10 @@ class GenerationMixin:
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
             if streamer is not None:
-                streamer.put(next_tokens.cpu())
+                #when does this even get invoked? doesn't seem to be getting hit in tests i don't think?
+                #streamer.put(next_tokens.cpu())
+                output_stub = GenerateDecoderOnlyOutput(sequences=next_tokens)
+                streamer.put(output_stub)
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder, model_inputs=model_inputs
             )
@@ -2462,7 +2465,9 @@ class GenerationMixin:
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
             if streamer is not None:
-                streamer.put(next_tokens.cpu())
+                #streamer.put(next_tokens.cpu())
+                output_stub = GenerateDecoderOnlyOutput(sequences=next_tokens)
+                streamer.put(output_stub)
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs,
                 model_kwargs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2775,8 +2775,12 @@ class GenerationMixin:
 
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
+
+            # I am confusion...
             if streamer is not None:
-                streamer.put(next_tokens.cpu())
+                #streamer.put(next_tokens.cpu())
+                streamer.put(GenerateDecoderOnlyOutput(sequences=next_tokens))
+
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder, model_inputs=model_inputs
             )

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2766,6 +2766,7 @@ class GenerationMixin:
             # sample
             probs = nn.functional.softmax(next_token_scores, dim=-1)
             next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
+            #print(next_tokens.dtype, input_ids.dtype) # both int64 here
 
             # finished sentences should have their next token be a padding token
             if eos_token_id is not None:
@@ -2779,7 +2780,12 @@ class GenerationMixin:
             # I am confusion...
             if streamer is not None:
                 #streamer.put(next_tokens.cpu())
-                streamer.put(GenerateDecoderOnlyOutput(sequences=next_tokens))
+                streamer.put(
+                    GenerateDecoderOnlyOutput(
+                        #sequences=next_tokens[:, None] # doesn't seem to make a difference. Handled downstream
+                        sequences=next_tokens,  # this seems to be getting coerced to float somewhere?
+                    )
+                )
 
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder, model_inputs=model_inputs

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -195,8 +195,12 @@ class TestOutputIteratorStreamer:
         thread.start()
 
         outputs = {'sequences':torch.Tensor()}
-        # todo: generalize this to support all encoder/decoder conditional attributes
-        for attr_name in ('scores', 'logits', 'decoder_attentions', 'attentions', 'hidden_states'):
+        for attr_name in (
+            'scores', 'logits',
+            'attentions', 'encoder_attentions', 'decoder_attentions', 'cross_attentions',
+            'hidden_states', 'encoder_hidden_states', 'decoder_hidden_states',
+            #'past_key_values' # uh... let's just say we're not going to support streaming the cache.
+        ):
             if hasattr(baseline_outputs, attr_name):
                 if getattr(baseline_outputs, attr_name) is not None:
                     #print(attr_name)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -168,12 +168,23 @@ class TestOutputIteratorStreamer:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
-        ### dmarx Force behaviors here for development
-        # only output attentions for greedy decoding
+        ### dmarx Force behaviors here for development ###########################################
+        # lol maybe these should just be separate tests....
+
+        # output attentions for...
+        # ...greedy decoding
         generation_kwargs['output_attentions'] = False
         if (not generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
             generation_kwargs['output_attentions'] = True
-        #### /dmarx
+
+        # ...multinomial sampling
+        if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
+            generation_kwargs['output_attentions'] = True
+
+        # output attentions for contrastive decoding
+        #if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is not None) and (generation_kwargs['top_k'] is not None) :
+        #    generation_kwargs['output_attentions'] = True
+        #### /dmarx ##############################################################################
 
         print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error
 
@@ -227,6 +238,7 @@ class TestOutputIteratorStreamer:
                         else:
                             outputs[output_name] += new_values # tuples gonna tuple...
 
+        print(outputs)
         for output_name in outputs.keys():
             print(output_name)
             baseline_values = getattr(baseline_outputs, output_name)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -195,13 +195,13 @@ class TestOutputIteratorStreamer:
         thread.start()
 
         outputs = {'sequences':torch.Tensor()}
-        # todo: generalize this to support encoder/decoder conditional attributes...
+        # todo: generalize this to support all encoder/decoder conditional attributes
         for attr_name in ('scores', 'logits', 'decoder_attentions', 'attentions', 'hidden_states'):
             if hasattr(baseline_outputs, attr_name):
                 if getattr(baseline_outputs, attr_name) is not None:
                     #print(attr_name)
                     #print(getattr(baseline_outputs, attr_name))
-                    outputs[attr_name] = () #torch.Tensor()
+                    outputs[attr_name] = ()
 
         n_times_field_extended = Counter()
         for answer in streamer:
@@ -209,20 +209,11 @@ class TestOutputIteratorStreamer:
             assert isinstance(answer, list)
             for output_object in answer:
                 for output_name in outputs.keys():
-                    print(output_name)
+                    #print(output_name)
                     new_values = getattr(output_object, output_name)
                     if (new_values is not None) and (len(new_values) > 0):
-                    #     if output_name != 'sequences':
-                    #         # unpack tuple
-                    #         new_values = new_values[0]
-                    #     print(new_values)
-                    #     new_values = new_values.cpu()
-                    #     if new_values.ndim == 1:
-                    #         new_values = new_values.unsqueeze(0)
-                    #     outputs[output_name] = torch.cat([outputs[output_name], new_values], axis=-1)
-                    #     n_times_field_extended[output_name] +=1
-                        print(type(outputs[output_name]), type(new_values))
-                        #with torch.device('cpu'):  # force everything on the same device...
+
+                        #print(type(outputs[output_name]), type(new_values))
                         if output_name == 'sequences':
                             new_values = new_values.cpu() # fml....
                             if new_values.ndim == 1:
@@ -231,11 +222,9 @@ class TestOutputIteratorStreamer:
                         else:
                             outputs[output_name] += new_values # tuples gonna tuple...
 
-        #with torch.cuda.device('cpu'): # force everything on the same device...
         for output_name in outputs.keys():
             print(output_name)
             baseline_values = getattr(baseline_outputs, output_name)
-            #nested_to_cpu(baseline_values)
             if isinstance(baseline_values, torch.Tensor):
                 baseline_values = baseline_values.cpu()
             #assert (baseline_values is not None) and (baseline_values != tuple())
@@ -251,30 +240,18 @@ class TestOutputIteratorStreamer:
             print("baseline", baseline_values)
             print("target", target_values)
             assert len(baseline_values) == len(target_values)
-            #assert baseline_values.tolist() == target_values.tolist()
-            #assert baseline_values == target_values
-            if isinstance(baseline_values, torch.Tensor):
-                assert torch.equal(baseline_values, target_values)
-            else:
-                for left, right in zip(baseline_values, target_values):
-                    if isinstance(left, torch.Tensor):
-                        assert torch.equal(left, right)
-                    else:
-                        assert len(left) == len(right)
-                        for left2, right2 in zip(left, right):
-                            if isinstance(left, torch.Tensor):
-                                assert torch.equal(left2, right2)
-                            else:
-                                assert len(left2) == len(right2)
-                                for left3, right3 in zip(left2, right2):
-                                    if isinstance(left3, torch.Tensor):
-                                        assert torch.equal(left3, right3)
-                                    else:
-                                        raise Exception("just shoot me already")
 
-        # # haven't supported this case yet.
-        # if generation_kwargs['output_attentions'] and generation_kwargs['do_sample']:
-        #     raise
+            # attention/hidden = tuples of tuples
+            def nested_tensor_equality(left, right):
+                assert type(left) == type(right)
+                assert len(left) == len(right)
+                if isinstance(left, torch.Tensor):
+                    assert torch.equal(left, right)
+                else:
+                    for left2, right2 in zip(left, right):
+                        assert nested_tensor_equality(left2, right2)
+                return True
+            assert nested_tensor_equality(baseline_values, target_values)
 
 
     @pytest.mark.parametrize("do_sample,top_k", [(False,None), (True,4)])

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -139,9 +139,11 @@ class TestOutputIteratorStreamer:
     @pytest.mark.parametrize("output_logits", [False, True])
     @pytest.mark.parametrize("output_attentions", [False, True])
     @pytest.mark.parametrize("model", ["hf-internal-testing/tiny-random-gpt2", "hf-internal-testing/tiny-random-bert", "hf-internal-testing/tiny-random-bart"]) # decoder, encoder, encoder-decoder
+    @pytest.mark.parametrize("assistant_model", [False, True])
     def test_outputs_match(self,
                            *,
                            model,
+                           assistant_model,
                            do_sample,
                            top_k,
                            penalty_alpha,
@@ -168,6 +170,8 @@ class TestOutputIteratorStreamer:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
+        if assistant_model:
+            generation_kwargs['assistant_model'] = copy.deepcopy(model)
         ### dmarx Force behaviors here for development ###########################################
         # lol maybe these should just be separate tests....
 
@@ -246,7 +250,7 @@ class TestOutputIteratorStreamer:
                 baseline_values = baseline_values.cpu()
             #assert (baseline_values is not None) and (baseline_values != tuple())
             assert (baseline_values is not None)
-            assert type(baseline_values) == type(getattr(output_object, output_name))
+            #assert type(baseline_values) == type(getattr(output_object, output_name))
             #assert n_times_field_extended[output_name] > 1 # make sure we're not just comparing to the final output tensor
             # TODO: pick a better "are these literally the same object" test
 
@@ -256,7 +260,9 @@ class TestOutputIteratorStreamer:
             #assert baseline_values.shape == target_values.shape
             print("baseline", baseline_values)
             print("target", target_values)
+            assert type(baseline_values) == type(target_values)
             assert len(baseline_values) == len(target_values)
+
 
             # attention/hidden = tuples of tuples
             def nested_tensor_equality(left, right):

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -138,23 +138,16 @@ class OutputIteratorStreamerTester(unittest.TestCase):
         streamer = OutputIteratorStreamer()
         generation_kwargs = {"input_ids": input_ids, "max_new_tokens": 10, "do_sample": False, "streamer": streamer}
         thread = Thread(target=model.generate, kwargs=generation_kwargs)
-        thread.start() # does this not need to be closed?
+        thread.start()
 
         stream_ids = torch.Tensor()
         for answer in streamer:
-            #if isinstance(answer, list):
             assert isinstance(answer, list)
             for output_object in answer:
-                #new_ids = output_object.sequences.cpu()
                 new_ids = output_object.cpu()
                 if new_ids.ndim == 1:
                     new_ids = new_ids.unsqueeze(0)
                 stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            # else:
-            #     new_ids = answer.sequences.cpu()
-            #     if new_ids.ndim == 1:
-            #         new_ids = new_ids.unsqueeze(0)
-            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
 
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
         self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
@@ -178,7 +171,7 @@ class OutputIteratorStreamerTester(unittest.TestCase):
         streamer = OutputIteratorStreamer()
         test_kwargs['streamer'] = streamer
         thread = Thread(target=model.generate, kwargs=test_kwargs)
-        thread.start() # does this not need to be closed?
+        thread.start()
 
         stream_ids = torch.Tensor()
         stream_scores = torch.Tensor()
@@ -199,20 +192,6 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                             new_scores = new_scores.unsqueeze(0)
                         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
                         n_times_scores_extended +=1
-
-            # # Boy do I need to DRY this
-            # else:
-            #     new_ids = answer.sequences.cpu()
-            #     if new_ids.ndim == 1:
-            #         new_ids = new_ids.unsqueeze(0)
-            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            #
-            #     if output_object.scores is not None:
-            #         new_scores = output_object.scores.cpu()
-            #         if new_scores.ndim == 1:
-            #             new_scores = new_scores.unsqueeze(0)
-            #         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
-            #         n_times_scores_extended += 1
 
         greedy_ids = baseline_outputs.sequences
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
@@ -244,7 +223,7 @@ class OutputIteratorStreamerTester(unittest.TestCase):
         test_kwargs['streamer'] = streamer
         torch.manual_seed(seed)
         thread = Thread(target=model.generate, kwargs=test_kwargs)
-        thread.start() # does this not need to be closed?
+        thread.start()
 
         stream_ids = torch.Tensor()
         stream_scores = torch.Tensor()
@@ -266,25 +245,10 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
                         n_times_scores_extended +=1
 
-            # Boy do I need to DRY this
-            # else:
-            #     new_ids = answer.sequences.cpu()
-            #     if new_ids.ndim == 1:
-            #         new_ids = new_ids.unsqueeze(0)
-            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            #
-            #     if output_object.scores is not None:
-            #         new_scores = output_object.scores.cpu()
-            #         if new_scores.ndim == 1:
-            #             new_scores = new_scores.unsqueeze(0)
-            #         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
-            #         n_times_scores_extended += 1
-
         greedy_ids = baseline_outputs.sequences
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
         self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
         self.assertTrue(n_times_scores_extended>1) # make sure we're not just comparing to the final output tensor
-
 
 
     def test_contrastive_ids_match(self):
@@ -307,23 +271,16 @@ class OutputIteratorStreamerTester(unittest.TestCase):
 
         torch.manual_seed(seed)
         thread = Thread(target=model.generate, kwargs=test_kwargs)
-        thread.start()  # does this not need to be closed?
+        thread.start()
 
         stream_ids = torch.Tensor()
         for answer in streamer:
-            #if isinstance(answer, list):
             assert isinstance(answer, list)
             for output_object in answer:
-                #new_ids = output_object.sequences.cpu()
                 new_ids = output_object.cpu()
                 if new_ids.ndim == 1:
                     new_ids = new_ids.unsqueeze(0)
                 stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            # else:
-            #     new_ids = answer.sequences.cpu()
-            #     if new_ids.ndim == 1:
-            #         new_ids = new_ids.unsqueeze(0)
-            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
 
         self.assertEqual(outputs_baseline.shape, stream_ids.shape)
         self.assertEqual(outputs_baseline.tolist(), stream_ids.tolist())

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -200,19 +200,19 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
                         n_times_scores_extended +=1
 
-            # Boy do I need to DRY this
-            else:
-                new_ids = answer.sequences.cpu()
-                if new_ids.ndim == 1:
-                    new_ids = new_ids.unsqueeze(0)
-                stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-
-                if output_object.scores is not None:
-                    new_scores = output_object.scores.cpu()
-                    if new_scores.ndim == 1:
-                        new_scores = new_scores.unsqueeze(0)
-                    stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
-                    n_times_scores_extended += 1
+            # # Boy do I need to DRY this
+            # else:
+            #     new_ids = answer.sequences.cpu()
+            #     if new_ids.ndim == 1:
+            #         new_ids = new_ids.unsqueeze(0)
+            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+            #
+            #     if output_object.scores is not None:
+            #         new_scores = output_object.scores.cpu()
+            #         if new_scores.ndim == 1:
+            #             new_scores = new_scores.unsqueeze(0)
+            #         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+            #         n_times_scores_extended += 1
 
         greedy_ids = baseline_outputs.sequences
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
@@ -267,18 +267,18 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                         n_times_scores_extended +=1
 
             # Boy do I need to DRY this
-            else:
-                new_ids = answer.sequences.cpu()
-                if new_ids.ndim == 1:
-                    new_ids = new_ids.unsqueeze(0)
-                stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-
-                if output_object.scores is not None:
-                    new_scores = output_object.scores.cpu()
-                    if new_scores.ndim == 1:
-                        new_scores = new_scores.unsqueeze(0)
-                    stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
-                    n_times_scores_extended += 1
+            # else:
+            #     new_ids = answer.sequences.cpu()
+            #     if new_ids.ndim == 1:
+            #         new_ids = new_ids.unsqueeze(0)
+            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+            #
+            #     if output_object.scores is not None:
+            #         new_scores = output_object.scores.cpu()
+            #         if new_scores.ndim == 1:
+            #             new_scores = new_scores.unsqueeze(0)
+            #         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+            #         n_times_scores_extended += 1
 
         greedy_ids = baseline_outputs.sequences
         self.assertEqual(greedy_ids.shape, stream_ids.shape)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -142,17 +142,19 @@ class OutputIteratorStreamerTester(unittest.TestCase):
 
         stream_ids = torch.Tensor()
         for answer in streamer:
-            if isinstance(answer, list):
-                for output_object in answer:
-                    new_ids = output_object.sequences.cpu()
-                    if new_ids.ndim == 1:
-                        new_ids = new_ids.unsqueeze(0)
-                    stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            else:
-                new_ids = answer.sequences.cpu()
+            #if isinstance(answer, list):
+            assert isinstance(answer, list)
+            for output_object in answer:
+                #new_ids = output_object.sequences.cpu()
+                new_ids = output_object.cpu()
                 if new_ids.ndim == 1:
                     new_ids = new_ids.unsqueeze(0)
                 stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+            # else:
+            #     new_ids = answer.sequences.cpu()
+            #     if new_ids.ndim == 1:
+            #         new_ids = new_ids.unsqueeze(0)
+            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
 
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
         self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
@@ -290,7 +292,9 @@ class OutputIteratorStreamerTester(unittest.TestCase):
         model.config.eos_token_id = -1
 
         input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
-        generation_kwargs = {"input_ids": input_ids, "max_new_tokens": 10, "do_sample": True, 'penalty_alpha': 0.6, 'top_k': 4}
+        generation_kwargs = {"input_ids": input_ids, "max_new_tokens": 10, "do_sample": True, 'penalty_alpha': 0.6, 'top_k': 4,
+                             "return_dict_in_generate": False, #pretty sure this is implied, just being explicit
+                             }
         baseline_kwargs = copy.deepcopy(generation_kwargs)
 
         seed = random.randint(0, int(1e9))
@@ -307,17 +311,19 @@ class OutputIteratorStreamerTester(unittest.TestCase):
 
         stream_ids = torch.Tensor()
         for answer in streamer:
-            if isinstance(answer, list):
-                for output_object in answer:
-                    new_ids = output_object.sequences.cpu()
-                    if new_ids.ndim == 1:
-                        new_ids = new_ids.unsqueeze(0)
-                    stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
-            else:
-                new_ids = answer.sequences.cpu()
+            #if isinstance(answer, list):
+            assert isinstance(answer, list)
+            for output_object in answer:
+                #new_ids = output_object.sequences.cpu()
+                new_ids = output_object.cpu()
                 if new_ids.ndim == 1:
                     new_ids = new_ids.unsqueeze(0)
                 stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+            # else:
+            #     new_ids = answer.sequences.cpu()
+            #     if new_ids.ndim == 1:
+            #         new_ids = new_ids.unsqueeze(0)
+            #     stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
 
         self.assertEqual(outputs_baseline.shape, stream_ids.shape)
         self.assertEqual(outputs_baseline.tolist(), stream_ids.tolist())

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -33,6 +33,9 @@ if is_torch_available():
 
     from transformers import AutoModelForCausalLM
 
+# for debugging only
+import lovely_tensors as lt
+lt.monkey_patch()
 
 @require_torch
 class StreamerTester(unittest.TestCase):
@@ -126,9 +129,6 @@ class StreamerTester(unittest.TestCase):
             for new_text in streamer:
                 streamer_text += new_text
 
-# for debugging only
-import lovely_tensors as lt
-lt.monkey_patch()
 
 @require_torch
 #class OutputIteratorStreamerTester(unittest.TestCase): # incompatible with pytest.mark.parameterize
@@ -149,9 +149,7 @@ class TestOutputIteratorStreamer:
         model.config.eos_token_id = -1
 
         input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
-        #generation_kwargs['input_ids'] = input_ids
-        #generation_kwargs['max_new_tokens'] = 10
-        #generation_kwargs['return_dict_in_generate'] = True
+
         generation_kwargs = dict(
             input_ids=input_ids,
             max_new_tokens=max_new_tokens,
@@ -169,8 +167,6 @@ class TestOutputIteratorStreamer:
         seed = random.randint(0, int(1e9))
         torch.manual_seed(seed)
         baseline_outputs = model.generate(**baseline_kwargs)
-        print(baseline_outputs)
-        #_,baseline_outputs = model.generate(**baseline_kwargs)
 
         streamer = OutputIteratorStreamer()
         test_kwargs['streamer'] = streamer
@@ -178,8 +174,6 @@ class TestOutputIteratorStreamer:
         thread = Thread(target=model.generate, kwargs=test_kwargs)
         thread.start()
 
-        # TODO: make sure output fields match what was requested and run equality checks per field
-        #stream_ids = torch.Tensor()
         outputs = {'sequences':torch.Tensor()}
         if output_scores:
             outputs['scores'] = torch.Tensor()
@@ -190,8 +184,6 @@ class TestOutputIteratorStreamer:
         if output_hidden_states:
             outputs['hidden_states'] = torch.Tensor()
 
-        #stream_scores = torch.Tensor()
-        #n_times_scores_extended = 0
         n_times_field_extended = Counter()
         for answer in streamer:
             if isinstance(answer, list):
@@ -199,36 +191,31 @@ class TestOutputIteratorStreamer:
                     for output_name in outputs.keys():
                         new_values = getattr(output_object, output_name)
                         if new_values is not None:
-                            #new_ids = output_object.sequences.cpu()
                             new_values = new_values.cpu()
                             if new_values.ndim == 1:
                                 new_values = new_values.unsqueeze(0)
                             outputs[output_name] = torch.cat([outputs[output_name], new_values], axis=-1)
                             n_times_field_extended[output_name] +=1
-        print(n_times_field_extended)
-        # TODO: rename "greedy_ids"
-        #greedy_ids = baseline_outputs.sequences
+
         for output_name in outputs.keys():
             print(output_name)
             baseline_values = getattr(baseline_outputs, output_name)
             assert baseline_values is not None
+
+            assert type(baseline_values) == type(getattr(output_object, output_name)) # scores = tuple(tensors) :(
             #print(baseline_values) # why is this a tuple...
             #TODO: apparently scores is *supposed* to be a tuple of tensors????
             if not isinstance(baseline_values, torch.Tensor):
                 baseline_values = torch.cat(baseline_values, axis=-1)
             target_values = outputs[output_name]
-            print(type(baseline_values), type(target_values))
+
             assert baseline_values.shape == target_values.shape
             assert baseline_values.tolist() == target_values.tolist()
             assert n_times_field_extended[output_name] > 1 # make sure we're not just comparing to the final output tensor
-            #self.assertEqual(baseline_values.shape, target_values.shape)
-            #self.assertEqual(baseline_values.tolist(), target_values.tolist())
-            #self.assertTrue(n_times_field_extended[output_name]>1) # make sure we're not just comparing to the final output tensor
 
     @pytest.mark.parametrize("do_sample,top_k", [(False,None), (True,4)])
     @pytest.mark.parametrize("penalty_alpha", [None, 0.6])
     def test_ids_only_match(self,
-                       #**generation_kwargs,
                             do_sample, top_k, penalty_alpha,
                             max_new_tokens=10,
                             return_dict_in_generate=False,

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -156,8 +156,6 @@ class TestOutputIteratorStreamer:
         model.config.eos_token_id = -1
         print(model.config)
 
-        input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
-
         generation_kwargs = dict(
             #input_ids=input_ids,
             max_new_tokens=max_new_tokens,
@@ -178,6 +176,8 @@ class TestOutputIteratorStreamer:
         #### /dmarx
 
         print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error
+
+        input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
         generation_kwargs['input_ids'] = input_ids
 
         baseline_kwargs = copy.deepcopy(generation_kwargs)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -138,8 +138,10 @@ class TestOutputIteratorStreamer:
     @pytest.mark.parametrize("output_scores", [False, True])
     @pytest.mark.parametrize("output_logits", [False, True])
     @pytest.mark.parametrize("output_attentions", [False, True])
+    @pytest.mark.parametrize("model", ["hf-internal-testing/tiny-random-gpt2", "hf-internal-testing/tiny-random-bert", "hf-internal-testing/tiny-random-bart"]) # decoder, encoder, encoder-decoder
     def test_outputs_match(self,
                            *,
+                           model,
                            do_sample,
                            top_k,
                            penalty_alpha,
@@ -148,10 +150,9 @@ class TestOutputIteratorStreamer:
                            output_attentions,
                            max_new_tokens=10,
                            return_dict_in_generate=True,
-                           #output_attentions=False,
-                           output_hidden_states=False
+                           output_hidden_states=False,
                            ):
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+        model = AutoModelForCausalLM.from_pretrained(model).to(torch_device)
         model.config.eos_token_id = -1
         print(model.config)
 

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -151,7 +151,7 @@ class TestOutputIteratorStreamer:
         input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
 
         generation_kwargs = dict(
-            input_ids=input_ids,
+            #input_ids=input_ids,
             max_new_tokens=max_new_tokens,
             return_dict_in_generate=return_dict_in_generate,
             do_sample=do_sample,
@@ -160,6 +160,8 @@ class TestOutputIteratorStreamer:
             output_scores=output_scores,
             output_logits=output_logits,
         )
+        print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error
+        generation_kwargs['input_ids'] = input_ids
 
         baseline_kwargs = copy.deepcopy(generation_kwargs)
         test_kwargs = copy.deepcopy(generation_kwargs)
@@ -228,7 +230,7 @@ class TestOutputIteratorStreamer:
         input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
 
         generation_kwargs = dict(
-            input_ids=input_ids,
+            #input_ids=input_ids,
             max_new_tokens=max_new_tokens,
             return_dict_in_generate=return_dict_in_generate,
             do_sample=do_sample,
@@ -237,6 +239,9 @@ class TestOutputIteratorStreamer:
             # output_scores=output_scores,
             # output_logits=output_logits,
         )
+        print(generation_kwargs) # easier than decoding pytest parameterization shorthand on error
+        generation_kwargs['input_ids'] = input_ids
+
 
         baseline_kwargs = copy.deepcopy(generation_kwargs)
 

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -190,7 +190,10 @@ class TestOutputIteratorStreamer:
                 for output_object in answer:
                     for output_name in outputs.keys():
                         new_values = getattr(output_object, output_name)
-                        if new_values is not None:
+                        if (new_values is not None) and (len(new_values) > 0):
+                            if output_name != 'sequences':
+                                # unpack tuple
+                                new_values = new_values[0]
                             new_values = new_values.cpu()
                             if new_values.ndim == 1:
                                 new_values = new_values.unsqueeze(0)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -173,17 +173,17 @@ class TestOutputIteratorStreamer:
 
         # output attentions for...
         # ...greedy decoding
-        generation_kwargs['output_attentions'] = False
-        if (not generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
-            generation_kwargs['output_attentions'] = True
-
-        # ...multinomial sampling
-        if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
-            generation_kwargs['output_attentions'] = True
-
-        # output attentions for contrastive decoding
-        if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is not None) and (generation_kwargs['top_k'] is not None) :
-            generation_kwargs['output_attentions'] = True
+        # generation_kwargs['output_attentions'] = False
+        # if (not generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
+        #     generation_kwargs['output_attentions'] = True
+        #
+        # # ...multinomial sampling
+        # if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is None):
+        #     generation_kwargs['output_attentions'] = True
+        #
+        # # output attentions for contrastive decoding
+        # if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is not None) and (generation_kwargs['top_k'] is not None) :
+        #     generation_kwargs['output_attentions'] = True
         #### /dmarx ##############################################################################
 
         print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -182,8 +182,8 @@ class TestOutputIteratorStreamer:
             generation_kwargs['output_attentions'] = True
 
         # output attentions for contrastive decoding
-        #if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is not None) and (generation_kwargs['top_k'] is not None) :
-        #    generation_kwargs['output_attentions'] = True
+        if (generation_kwargs['do_sample']) and (generation_kwargs['penalty_alpha'] is not None) and (generation_kwargs['top_k'] is not None) :
+            generation_kwargs['output_attentions'] = True
         #### /dmarx ##############################################################################
 
         print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -165,11 +165,13 @@ class TestOutputIteratorStreamer:
             penalty_alpha=penalty_alpha,
             output_scores=output_scores,
             output_logits=output_logits,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
         )
         ### dmarx Force behaviors here for development
         # only output attentions for greedy sampling
-        if not (generation_kwargs['do_sample'] and (generation_kwargs['penalty_alpha'] is None)):
-            generation_kwargs['output_attentions'] = False
+        #if not (generation_kwargs['do_sample'] and (generation_kwargs['penalty_alpha'] is None)):
+        #    generation_kwargs['output_attentions'] = False
         #### /dmarx
 
         print(generation_kwargs)  # easier than decoding pytest parameterization shorthand on error
@@ -224,6 +226,10 @@ class TestOutputIteratorStreamer:
             target_values = outputs[output_name]
             assert baseline_values.shape == target_values.shape
             assert baseline_values.tolist() == target_values.tolist()
+
+        # haven't supported this case yet.
+        if generation_kwargs['output_attentions'] and generation_kwargs['do_sample']:
+            raise
 
 
     @pytest.mark.parametrize("do_sample,top_k", [(False,None), (True,4)])

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -139,11 +139,11 @@ class TestOutputIteratorStreamer:
     @pytest.mark.parametrize("output_logits", [False, True])
     @pytest.mark.parametrize("output_attentions", [False, True])
     @pytest.mark.parametrize("model", ["hf-internal-testing/tiny-random-gpt2", "hf-internal-testing/tiny-random-bert", "hf-internal-testing/tiny-random-bart"]) # decoder, encoder, encoder-decoder
-    @pytest.mark.parametrize("assistant_model", [False, True])
+    #@pytest.mark.parametrize("assistant_model", [False, True]) # having issues
     def test_outputs_match(self,
                            *,
                            model,
-                           assistant_model,
+                           #assistant_model,
                            do_sample,
                            top_k,
                            penalty_alpha,
@@ -170,8 +170,12 @@ class TestOutputIteratorStreamer:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
         )
-        if assistant_model:
-            generation_kwargs['assistant_model'] = copy.deepcopy(model)
+        # if assistant_model:
+        #     # attentions acting funny. suppress for now
+        #     if not output_attentions:
+        #         generation_kwargs['assistant_model'] = copy.deepcopy(model)
+        #         generation_kwargs['assistant_model'].config.eos_token_id = 999 # assistant model needs to have a valid eos_token_id I think
+
         ### dmarx Force behaviors here for development ###########################################
         # lol maybe these should just be separate tests....
 

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -164,14 +164,15 @@ class OutputIteratorStreamerTester(unittest.TestCase):
         generation_kwargs = {"input_ids": input_ids, "max_new_tokens": 10, "do_sample": True, 'penalty_alpha': 0.6, 'top_k': 4}
         baseline_kwargs = copy.deepcopy(generation_kwargs)
 
-        torch.manual_seed(0)
+        seed = random.randint(0, int(1e9))
+        torch.manual_seed(seed)
         outputs_baseline = model.generate(**baseline_kwargs)
 
         streamer = OutputIteratorStreamer()
         test_kwargs = copy.deepcopy(generation_kwargs)
         test_kwargs['streamer'] = streamer
 
-        torch.manual_seed(0)
+        torch.manual_seed(seed)
         thread = Thread(target=model.generate, kwargs=test_kwargs)
         thread.start()  # does this not need to be closed?
 

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 import copy
-import unittest
 from queue import Empty
+import random
 from threading import Thread
+import unittest
 
 from transformers import AutoTokenizer, TextIteratorStreamer, TextStreamer, is_torch_available #, OutputIteratorStreamer
 from transformers.generation.streamers import OutputIteratorStreamer # TODO: fix import
@@ -155,6 +156,63 @@ class OutputIteratorStreamerTester(unittest.TestCase):
 
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
         self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
+
+
+    def test_greedy_outputs_match(self):
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+        model.config.eos_token_id = -1
+
+        input_ids = ids_tensor((1, 5), vocab_size=model.config.vocab_size).to(torch_device)
+        generation_kwargs = {"input_ids": input_ids, "max_new_tokens": 10, "do_sample": False,
+                             'return_dict_in_generate': True,
+                             'output_scores': True,
+                             'output_logits': True,
+                             }
+        baseline_kwargs = copy.deepcopy(generation_kwargs)
+        test_kwargs = copy.deepcopy(generation_kwargs)
+
+        baseline_outputs = model.generate(**baseline_kwargs)
+
+        streamer = OutputIteratorStreamer()
+        test_kwargs['streamer'] = streamer
+        thread = Thread(target=model.generate, kwargs=test_kwargs)
+        thread.start() # does this not need to be closed?
+
+        stream_ids = torch.Tensor()
+        stream_scores = torch.Tensor()
+        for answer in streamer:
+            if isinstance(answer, list):
+                for output_object in answer:
+                    print(output_object.__dict__.keys())
+                    new_ids = output_object.sequences.cpu()
+                    if new_ids.ndim == 1:
+                        new_ids = new_ids.unsqueeze(0)
+                    stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+
+                    # We don't get scores back from the prompt
+                    if output_object.scores is not None:
+                        new_scores = output_object.scores.cpu()
+                        if new_scores.ndim == 1:
+                            new_scores = new_scores.unsqueeze(0)
+                        stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+
+            # Boy do I need to DRY this
+            else:
+                new_ids = answer.sequences.cpu()
+                if new_ids.ndim == 1:
+                    new_ids = new_ids.unsqueeze(0)
+                stream_ids = torch.cat([stream_ids, new_ids], axis=-1)
+
+                if output_object.scores is not None:
+                    new_scores = output_object.scores.cpu()
+                    if new_scores.ndim == 1:
+                        new_scores = new_scores.unsqueeze(0)
+                    stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+
+        greedy_ids = baseline_outputs.sequences
+        self.assertEqual(greedy_ids.shape, stream_ids.shape)
+        self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
+
 
     def test_contrastive_ids_match(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)

--- a/tests/generation/test_streamers.py
+++ b/tests/generation/test_streamers.py
@@ -180,10 +180,11 @@ class OutputIteratorStreamerTester(unittest.TestCase):
 
         stream_ids = torch.Tensor()
         stream_scores = torch.Tensor()
+        n_times_scores_extended = 0
         for answer in streamer:
             if isinstance(answer, list):
                 for output_object in answer:
-                    print(output_object.__dict__.keys())
+
                     new_ids = output_object.sequences.cpu()
                     if new_ids.ndim == 1:
                         new_ids = new_ids.unsqueeze(0)
@@ -195,6 +196,7 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                         if new_scores.ndim == 1:
                             new_scores = new_scores.unsqueeze(0)
                         stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+                        n_times_scores_extended +=1
 
             # Boy do I need to DRY this
             else:
@@ -208,10 +210,12 @@ class OutputIteratorStreamerTester(unittest.TestCase):
                     if new_scores.ndim == 1:
                         new_scores = new_scores.unsqueeze(0)
                     stream_scores = torch.cat([stream_scores, new_scores], axis=-1)
+                    n_times_scores_extended += 1
 
         greedy_ids = baseline_outputs.sequences
         self.assertEqual(greedy_ids.shape, stream_ids.shape)
         self.assertEqual(greedy_ids.tolist(), stream_ids.tolist())
+        self.assertTrue(n_times_scores_extended>1) # make sure we're not just comparing to the final output tensor
 
 
     def test_contrastive_ids_match(self):


### PR DESCRIPTION
# What does this PR do?

The "streaming" feature for text generation is currently constrained to streaming token ids. If a user requests an output dict, the stream still only generates token ids without other attributes that may have been requested such as scores, raw logits, activations. After the stream has been consumed, the function returns its final output, which will be the originally requested output dict. 

This PR aligns the return type of the streamer with the requested return type by encapsulating the logic that determines how the return value is constructed. In so doing, this change also permits users to stream richer representations than just token ids.

Summary of changes:
* Adds a `._prepare_output()` function to `GenerationMixin`, encapsulates output formatting logic
* `._prepare_output()` replaces nested conditionals that previously built return values (beam samplers excluded)
* `Streamer.put()` receives its input from `._prepare_output()` invocation rather than restricted to token IDs tensor
* Inputs to `Streamer.put()` are no longer sent to the CPU prior to being passed to `.put()`
  * When desired, delegates responsibility for moving the tensor to the provided `Streamer`.
* Adds `OutputStreamer` and `OutputIteratorStreamer` classes

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Did you write any new necessary tests?
  - [x] `OutputIteratorStreamerTester` to be modularized with fixtures, DRYed
- [x] test against hydra-node
- [x] fix inconsistent list output from OutputStreamer.on_ready
- [ ] flesh out rest of intermediate return values
  - [x] scores
  - [x] logits
  - [x] attention
  - [ ] hidden  
- [x] add some kind of "output formatter" factory to ensure outputs are uniform across the class w/o repeating a ton of logic.
  - [x] encapsulate output construction logic in a function
  - [x] refactor to use function
  - [x] add tests validating output type consistency and parity with streamer.put()
- [ ] ensure tests fully cover targeted cases
  * I'm concerned that injecting bad data directly into these attributes doesn't seem to trigger test failures
  - [ ] encoder attentions
  - [ ] cross attentions
  - [ ] [contrastive search] decoder attention
  - [ ] suspect tests not covering assisted decoding
  - [ ] added encoder and encoder-decoder models to test suite, need to smoke test 
- [ ] update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
  - [x] Send the CW documentation team a CR
  - [ ] docstrings
  - [ ] typehints
  - [ ] explicit input args for `_prepare_output()` (? maybe it's fine as is?)
- [ ] fix import
- [ ] fix inconsistent tensor dimensions
- [x] fix sigterm on hydra-node
- ~~[ ] revisit ECHO behavior?~~
  - on our end, just skipping over streamed outputs when `output.score is None`
  - should be sufficient for HF's end if we just document that the ECHO response will have null scores/logits/activations
- [ ] reimplement their `TextIteratorStreamer` using the new `OutputIteraterSreamer`


## Who can review?

(Hidden `@` tag, uncomment when ready to send to HF)

<!-- UNCOMMENT ME WHEN READY FOR HF
@gante
/ UNCOMMENT ME WHEN READY FOR HF -->

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
